### PR TITLE
fix(CI): account for weird LF configuration bug in GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,12 +10,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
     # Fixes: https://github.com/actions/checkout/issues/135
     - name: Set git to use LF.
       run: |
         git config --global core.autocrlf false
         git config --global core.eol lf
+    - uses: actions/checkout@v3
     - name: Install dependencies.
       run: sudo apt-get install -y clang-format
     - name: Lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
     # Fixes: https://github.com/actions/checkout/issues/135

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    # Fixes: https://github.com/actions/checkout/issues/135
+    - name: Set git to use LF.
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
     - name: Install dependencies.
       run: sudo apt-get install -y clang-format
     - name: Lint

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ dockerun:
 	$(QEMU) -drive format=raw,file=$(BUILD_DIR)/os_image
 
 check:
-	@grep -RE "\r" source/ && echo "Found carriage returns in source files. Please run 'make format' to fix them." && exit 1 || exit 0
+	@grep -RE "$'\r'" source/ && echo "Found carriage returns in source files. Please run 'make format' to fix them." && exit 1 || exit 0
 	@find source/ -type f -name '*.c' -or -name '*.h' | xargs $(FORMAT) --dry-run --Werror && echo "All files are formatted correctly." || echo "Some files are not formatted correctly. Please run 'make format' to fix them."
 
 format:

--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,12 @@ dockerun:
 	$(QEMU) -drive format=raw,file=$(BUILD_DIR)/os_image
 
 check:
-	# For some reason, GitHub Actions seems to add carriage returns?
-	# @grep -RE "\r" source/ && echo "Found carriage returns in source files. Please run 'make format' to fix them." && exit 1 || exit 0
-	find source/ -type f -name '*.c' -or -name '*.h' | xargs $(FORMAT) --dry-run --Werror
+	@grep -RE "\r" source/ && echo "Found carriage returns in source files. Please run 'make format' to fix them." && exit 1 || exit 0
+	@find source/ -type f -name '*.c' -or -name '*.h' | xargs $(FORMAT) --dry-run --Werror && echo "All files are formatted correctly." || echo "Some files are not formatted correctly. Please run 'make format' to fix them."
 
 format:
-	find source -type f -name '*.c' -or -name '*.h' -or -name '*.asm' | xargs dos2unix
-	find source/ -type f -name '*.c' -or -name '*.h' | xargs $(FORMAT)
+	@find source -type f -name '*.c' -or -name '*.h' -or -name '*.asm' | xargs dos2unix > /dev/null 2>&1 && echo "Converted carriage returns to line feeds."
+	@find source/ -type f -name '*.c' -or -name '*.h' | xargs $(FORMAT) && echo "Formatted all files."
 
 clean: 
 	rm -rf $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ dockerun:
 	$(QEMU) -drive format=raw,file=$(BUILD_DIR)/os_image
 
 check:
-	@grep -RE "$'\r'" source/ && echo "Found carriage returns in source files. Please run 'make format' to fix them." && exit 1 || exit 0
+	@grep -RE $$'\r' source/ && echo "Found carriage returns in source files. Please run 'make format' to fix them." && exit 1 || exit 0
 	@find source/ -type f -name '*.c' -or -name '*.h' | xargs $(FORMAT) --dry-run --Werror && echo "All files are formatted correctly." || echo "Some files are not formatted correctly. Please run 'make format' to fix them."
 
 format:


### PR DESCRIPTION
There is a weird bug with GitHub Actions that causes `CRLF` line endings to be enforced. This attempts to fix this issue when running the CI.

**Issue:** https://github.com/actions/checkout/issues/135

**Update:** There was just an issue with the regex. 🤦 